### PR TITLE
Provides missing util.js when used as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "files": [
     "bundle.js",
-    "fox.json"
+    "fox.json",
+    "util.js"
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "lint:fix": "yarn lint --fix"
   },
   "files": [
-    "bundle.js",
     "fox.json",
     "util.js"
   ],


### PR DESCRIPTION
When this was refactored for hackability (https://github.com/MetaMask/logo/pull/43), we moved to using a `util.js` file for some of the parsing.  This wasn't added to the `package.json`'s `files` array before publishing `3.0.0` today (https://github.com/MetaMask/logo/pull/52) so this module becomes problematic when using as a dependency.

I've globally installed `npm-previewpkg` on my machine to preview files exported from a package to prevent this from happening again.