### PR TITLE
Use `yargs` for `convert.js` CLI

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -1,11 +1,8 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require('fs').promises;
 const OBJFile = require('obj-file-parser');
-
-// eslint-disable-next-line node/no-sync
-const obj = fs.readFileSync('./fox.obj').toString();
-// eslint-disable-next-line node/no-sync
-const mtlRaw = fs.readFileSync('./fox.mtl').toString('utf8');
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
+const prettier = require('prettier');
 
 function parseMTL(mtl) {
   const output = {};
@@ -39,78 +36,118 @@ function parseMTL(mtl) {
   return output;
 }
 
-const mtl = parseMTL(mtlRaw);
+async function main() {
+  const { argv } = yargs(hideBin(process.argv))
+    .usage(
+      '$0 [options]',
+      'Convert Maya .obj and .mtl files into our JSON model format.',
+      (_yargs) =>
+        _yargs
+          .option('out', {
+            default: 'fox.json',
+            description: 'The output file path',
+            type: 'string',
+            normalize: true,
+          })
+          .option('obj', {
+            default: 'fox.obj',
+            description: 'The input OBJ file path',
+            type: 'string',
+            normalize: true,
+          })
+          .option('mtl', {
+            default: 'fox.mtl',
+            description: 'The input MTL file path',
+            type: 'string',
+            normalize: true,
+          }),
+    )
+    .version(false)
+    .strict();
 
-const objF = new OBJFile(obj);
+  const { out: outputFilename, obj: objFilename, mtl: mtlFilename } = argv;
 
-const data = objF.parse(objF);
+  const [objContents, mtlContents] = await Promise.all([
+    fs.readFile(objFilename, 'utf8'),
+    fs.readFile(mtlFilename, 'utf8'),
+  ]);
 
-const outpath = path.join(__dirname, 'fox.json');
+  const mtl = parseMTL(mtlContents);
+  const objFile = new OBJFile(objContents);
+  const data = objFile.parse(objFile);
 
-const output = {
-  positions: [],
-  chunks: [],
-};
+  const output = {
+    positions: [],
+    chunks: [],
+  };
 
-/*
+  /*
+  type colorValue = number; // 0-255
+  type positionId = number; // Index of that position
+  type CoordVal = number;
 
-type colorValue = number; // 0-255
-type positionId = number; // Index of that position
-type CoordVal = number;
+  type Position = [CoordVal, CoordVal, CoordVal];
+  type Face = [positionId, positionId, positionId];
 
-type Position = [CoordVal, CoordVal, CoordVal];
-type Face = [positionId, positionId, positionId];
-
-export type EfficientModel = {
-  positions: Array<Position>;
-  chunks: Array<{
-    color: [colorValue, colorValue, colorValue];
-    faces: Array<Face>;
-  }>;
-}
-
-*/
-const VI = 'vertexIndex';
-
-const model = data.models[0];
-model.vertices.forEach((v) => {
-  output.positions.push([v.x, v.y, v.z]);
-});
-
-for (const mtlKey of Object.keys(mtl)) {
-  const m = mtl[mtlKey];
-
-  if (m.Ka) {
-    const color = m.Kd.map(function (c) {
-      return Math.floor(255 * c);
-    });
-    m.Kd.forEach((c, i) => {
-      if (color[i] === 0) {
-        color[i] = Math.floor(255 * c);
-      }
-    });
-
-    const chunk = {
-      color,
-      faces: [],
-    };
-
-    model.faces.forEach((f) => {
-      // Only if this face matches the material!
-      if (f.material === mtlKey) {
-        chunk.faces.push([
-          f.vertices[0][VI] - 1,
-          f.vertices[1][VI] - 1,
-          f.vertices[2][VI] - 1,
-        ]);
-      }
-    });
-
-    output.chunks.push(chunk);
-  } else {
-    throw new Error(`Invalid MTL entry at key '${mtlKey}'`);
+  export type EfficientModel = {
+    positions: Array<Position>;
+    chunks: Array<{
+      color: [colorValue, colorValue, colorValue];
+      faces: Array<Face>;
+    }>;
   }
+
+  */
+  const VI = 'vertexIndex';
+
+  const model = data.models[0];
+  model.vertices.forEach((v) => {
+    output.positions.push([v.x, v.y, v.z]);
+  });
+
+  for (const mtlKey of Object.keys(mtl)) {
+    const m = mtl[mtlKey];
+
+    if (m.Ka) {
+      const color = m.Kd.map(function (c) {
+        return Math.floor(255 * c);
+      });
+      m.Kd.forEach((c, i) => {
+        if (color[i] === 0) {
+          color[i] = Math.floor(255 * c);
+        }
+      });
+
+      const chunk = {
+        color,
+        faces: [],
+      };
+
+      model.faces.forEach((f) => {
+        // Only if this face matches the material!
+        if (f.material === mtlKey) {
+          chunk.faces.push([
+            f.vertices[0][VI] - 1,
+            f.vertices[1][VI] - 1,
+            f.vertices[2][VI] - 1,
+          ]);
+        }
+      });
+
+      output.chunks.push(chunk);
+    } else {
+      throw new Error(`Invalid MTL entry at key '${mtlKey}'`);
+    }
+  }
+
+  const stringifiedOutput = JSON.stringify(output, null, 2);
+  const formattedOutput = prettier.format(stringifiedOutput, {
+    filepath: outputFilename,
+  });
+  await fs.writeFile(outputFilename, formattedOutput);
 }
 
-// eslint-disable-next-line node/no-sync
-fs.writeFileSync(outpath, JSON.stringify(output, null, 2));
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "obj-file-parser-ts": "^0.6.4",
     "prettier": "^2.2.1",
     "prettier-plugin-packagejson": "^2.2.11",
-    "uglifyify": "^5.0.2"
+    "uglifyify": "^5.0.2",
+    "yargs": "^17.2.1"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3478,3 +3478,16 @@ yargs@^17.0.1:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+yargs@^17.2.1:
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
+  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"


### PR DESCRIPTION
The `yargs` library is now used for the `convert.js` script. It allows customizing the input and output files, and it includes documentation for the command and all options.

This was done in preparation for further customization to the convert process that will come in later PRs.

Additionally, the output file is now formatted using `prettier` before being written to disk. This was to make updating the main `fox.json` easier (otherwise you'd need to run `yarn lint:fix` after each change).