### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/demo/build.js
+++ b/demo/build.js
@@ -101,6 +101,12 @@ async function main() {
           description: 'Build all demos.',
           type: 'boolean',
         })
+        .option('clear', {
+          default: false,
+          description: 'Empty the demo directory before building',
+          requiresArg: 'all',
+          type: 'boolean',
+        })
         .positional('demo-name', {
           describe: 'The name of the demo to build.',
           type: 'string',
@@ -109,7 +115,7 @@ async function main() {
     .version(false)
     .strict();
 
-  const { all, demoName } = argv;
+  const { all, clear, demoName } = argv;
 
   const demoSourceDir = path.join(__dirname, 'src');
 
@@ -123,7 +129,7 @@ async function main() {
       throw new UsageError('No demo files found');
     }
 
-    await buildIndex({ clear: true });
+    await buildIndex({ clear });
     for (const currentDemoName of demoNames) {
       await buildDemo(currentDemoName);
     }


### PR DESCRIPTION
The GitHub pages deployment is broken because the `dist` directory is cleared when the `yarn demo:all` script is run, which also deletes the git worktree used to push the `gh-pages` changes.

Instead the `dist` directory is not cleared by default. The `--clear` option must be given to clear the directory. CI will not use this option because it's guaranteed to be empty already on CI, which fixes the deployment. The `--clear` option is also dependent upon `--all`, because it also deletes all demos.

I had actually fixed this bug already on my personal fork, but forgot to push this change to the `MetaMask/logo` branch before marking the PR as ready for review. This commit represents the code that was actually tested to work.