### PR TITLE
Automate the extraction of gradient definitions from SVGs

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "prettier": "^2.2.1",
     "prettier-plugin-packagejson": "^2.2.11",
     "rimraf": "^3.0.2",
+    "svg-parser": "^2.0.4",
     "uglifyify": "^5.0.2",
     "yargs": "^17.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3153,6 +3153,11 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+svg-parser@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
+  integrity sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==
+
 syntax-error@^1.1.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/syntax-error/-/syntax-error-1.4.0.tgz#2d9d4ff5c064acb711594a3e3b95054ad51d907c"


### PR DESCRIPTION
Gradient definitions can now be automatically extracted from SVGs using the `convert.js` script. This is done with the new `gradient` option, which you use to pass in the path of the SVG to extract gradients from.

The gradient definitions still aren't linked up to any chunks, so you still have to do that part manually. But this dramatically speeds up the process of updating the model JSON to use gradients.

Mostly what the script does is read the gradient definitions in the SVG file and convert them to our model JSON gradient definition format. The only other change it makes is to change the gradient coordinate properties from absolute values to percentages. This ensures that the gradient definitions scale properly with different logo sizes. As part of this process we also add 10% padding on each side, because the 3D model itself typically has roughly that amount of padding on each side of the fox head, whereas the source SVG file typically is cropped exactly to the edges of the fox. We may need to adjust the padding in the future, but 10% seemed to produce fairly accurate gradients for the beta fox.