### PR TITLE
Polyfill replaceChildren

### DIFF
--- a/util.js
+++ b/util.js
@@ -7,6 +7,18 @@ const transform = require('gl-vec3/transformMat4');
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
+// Taken from https://github.com/yuzhe-han/ParentNode-replaceChildren
+// This is to support browsers that do not yet support `replaceChildren`
+const replaceChildrenPolyfill = function (...addNodes) {
+  while (this.lastChild) {
+    this.removeChild(this.lastChild);
+  }
+
+  if (addNodes !== undefined) {
+    this.append(...addNodes);
+  }
+};
+
 module.exports = {
   calculateSizingOptions,
   createLogoViewer,
@@ -497,7 +509,15 @@ function createFaceUpdater(container, polygons, transformed) {
     const newPolygons = toDraw.map((poly) => poly.svg);
     const defs = container.getElementsByTagName('defs');
     const maskChildren = container.getElementsByTagName('mask');
-    container.replaceChildren(...defs, ...maskChildren, ...newPolygons);
+    if (container.replaceChildren) {
+      container.replaceChildren(...defs, ...maskChildren, ...newPolygons);
+    } else {
+      replaceChildrenPolyfill.bind(container)(
+        ...defs,
+        ...maskChildren,
+        ...newPolygons,
+      );
+    }
   };
 }
 

--- a/util.js
+++ b/util.js
@@ -14,7 +14,7 @@ const replaceChildrenPolyfill = function (...addNodes) {
     this.removeChild(this.lastChild);
   }
 
-  if (addNodes !== undefined) {
+  if (addNodes.length > 0) {
     this.append(...addNodes);
   }
 };

--- a/util.js
+++ b/util.js
@@ -9,7 +9,7 @@ const SVG_NS = 'http://www.w3.org/2000/svg';
 
 // Taken from https://github.com/yuzhe-han/ParentNode-replaceChildren
 // This is to support browsers that do not yet support `replaceChildren`
-const replaceChildrenPolyfill = function (...addNodes) {
+const replaceChildrenPonyfill = function (...addNodes) {
   while (this.lastChild) {
     this.removeChild(this.lastChild);
   }
@@ -512,7 +512,7 @@ function createFaceUpdater(container, polygons, transformed) {
     if (container.replaceChildren) {
       container.replaceChildren(...defs, ...maskChildren, ...newPolygons);
     } else {
-      replaceChildrenPolyfill.bind(container)(
+      replaceChildrenPonyfill.bind(container)(
         ...defs,
         ...maskChildren,
         ...newPolygons,


### PR DESCRIPTION
`replaceChildren` is not supported on older browsers. See https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren#browser_compatibility

This PR uses the polyfill from https://github.com/yuzhe-han/ParentNode-replaceChildren in cases where `replaceChildren` is unavailable.