### PR TITLE
chore: Update `convert` to support four-sided polygon inputs

### DIFF
--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -278,7 +278,7 @@ async function main() {
       const triangleVertices =
         rawVertices.length === 3
           ? [rawVertices]
-          : // The vertex omitted by each triange must be opposite each other so that the triangles
+          : // The vertex omitted by each triangle must be opposite each other so that the triangles
             // evenly split the polygon in two, rather than overlapping. e.g.
             // A---B
             // |   |

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -297,7 +297,6 @@ async function main() {
             currentChunks.push({
               color,
               polygons: [polygon],
-              materialName: mtlKey,
             });
           }
           continue;

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -278,7 +278,13 @@ async function main() {
       const triangleVertices =
         rawVertices.length === 3
           ? [rawVertices]
-          : [
+          : // The vertex omitted by each triange must be opposite each other so that the triangles
+            // evenly split the polygon in two, rather than overlapping. e.g.
+            // A---B
+            // |   |
+            // D---C
+            // Here the two triangles we use are A-B-C and A-C-D
+            [
               rawVertices.slice().toSpliced(3, 1),
               rawVertices.slice().toSpliced(1, 1),
             ];

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -303,22 +303,19 @@ async function main() {
           continue;
         }
 
+        const xVertex = currentVertices[0];
+        const yVertex = currentVertices[1];
+        const zVertex = currentVertices[2];
+
         // Search the current list of chunks for the current color that include an adjacent polygon.
         // A polygon is adjacent if it shares two vertices.
         const chunksWithAdjacentPolygons = currentChunks.filter((chunk) =>
-          chunk.polygons.some(({ vertices }) => {
-            const firstSharedVertexIndex = currentVertices.findIndex((vertex) =>
-              vertices.includes(vertex),
-            );
-            const lastSharedVertexIndex = currentVertices.findIndex((vertex) =>
-              vertices.includes(vertex),
-            );
-            return (
-              firstSharedVertexIndex &&
-              lastSharedVertexIndex &&
-              firstSharedVertexIndex !== lastSharedVertexIndex
-            );
-          }),
+          chunk.polygons.some(
+            ({ vertices }) =>
+              (vertices.includes(xVertex) &&
+                (vertices.includes(yVertex) || vertices.includes(zVertex))) ||
+              (vertices.includes(yVertex) && vertices.includes(zVertex)),
+          ),
         );
 
         let chunk;

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -302,9 +302,7 @@ async function main() {
           continue;
         }
 
-        const xVertex = currentVertices[0];
-        const yVertex = currentVertices[1];
-        const zVertex = currentVertices[2];
+        const [xVertex, yVertex, zVertex] = currentVertices;
 
         // Search the current list of chunks for the current color that include an adjacent polygon.
         // A polygon is adjacent if it shares two vertices.


### PR DESCRIPTION
The `.obj` input for the `convert` script can contain three or four- sided polygons, but only three-sided polygons were supported in practice (both by the conversion script, and the runtime code). The script has been updated to split four-sided polygons into triangles.