### PR TITLE
feat: Add options to adjust render perspective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add options for controlling render perspective ([#122](https://github.com/MetaMask/logo/pull/122))
+  - The options are `verticalFieldOfView`, `near`, and `far`.
+  - These options were added to `createLogo`, `createModelRenderer`, and `createMatrixComputer`.
+
 ### Changed
 - Add material labels to default JSON model (`fox.json`) ([#119](https://github.com/MetaMask/logo/pull/119))
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,9 @@ module.exports = createLogo;
  * @param {boolean} [options.lazyRender] - Determines whether to render each animation frame, or
  * just when requested (e.g. by mouse/device movement).
  * @param {number} [options.cameraDistance] - The distance between the model and the camera.
+ * @param {number} [options.verticalFieldOfView] - Vertical field of view (in radians).
+ * @param {number} [options.near] - Near bound of the frustrum.
+ * @param {number} [options.far] - Far bound of the frustrum.
  * @param {number} [options.width] - Width, either in pixels or as a ratio of window width.
  * @param {number} [options.height] - Height, either in pixels or as a ratio of window height.
  * @param {number} [options.minWidth] - Minimum width (in pixels), used as a lower bound if the
@@ -43,6 +46,9 @@ function createLogo({
   // render options
   lazyRender = true,
   cameraDistance = defaultCameraDistance,
+  verticalFieldOfView = Math.PI / 4.0,
+  near = 100,
+  far = 1000,
   // size options
   width: specifiedWidth,
   height: specifiedHeight,
@@ -65,7 +71,11 @@ function createLogo({
   setMaskDefinitions({ container, masks: meshJson.masks, height, width });
 
   const modelObj = loadModelFromJson(meshJson);
-  const renderFox = createModelRenderer(container, cameraDistance, modelObj);
+  const renderFox = createModelRenderer(container, cameraDistance, modelObj, {
+    verticalFieldOfView,
+    near,
+    far,
+  });
   const renderScene = (lookCurrent, _slowDrift) => {
     const rect = container.getBoundingClientRect();
     renderFox(rect, lookCurrent, _slowDrift);


### PR DESCRIPTION
Add options "verticalFieldOfView", "near", and "far" "to adjust the render's perspective. These options were added to `createLogo`, `createModelRenderer`, and `createMatrixComputer`.

These options allow adjusting the perspective distortion applied to the logo, and they also impact how dramatically the logo moves in response to mouse and device movement.