### PR TITLE
chore: Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# Lines starting with '#' are comments.
-# Each line is a file pattern followed by one or more owners.
-
-*                                    @MetaMask/devs


### PR DESCRIPTION
We are deprecating the `devs` team referenced. That team was essentially meant to be equivalent to the set of users with write access anyway, so removing this rule won't meaningfully change review requirements..